### PR TITLE
chore: update Next.js policy to track latest and require npm >=11.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "my-v0-project",
       "version": "0.1.0",
       "dependencies": {
-        "@hookform/resolvers": "*",
+        "@hookform/resolvers": "latest",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.4",
         "@radix-ui/react-aspect-ratio": "^1.1.1",
@@ -36,33 +36,33 @@
         "@radix-ui/react-toggle": "^1.1.1",
         "@radix-ui/react-toggle-group": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.1.6",
-        "@types/hoist-non-react-statics": "*",
+        "@types/hoist-non-react-statics": "latest",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "1.0.4",
-        "date-fns": "*",
+        "date-fns": "latest",
         "embla-carousel-react": "8.5.1",
-        "immer": "*",
+        "immer": "latest",
         "input-otp": "1.4.1",
         "lucide-react": "^0.454.0",
-        "next": "16.1.5",
+        "next": "latest",
         "next-themes": "^0.4.4",
         "react": "^19",
-        "react-day-picker": "*",
-        "react-dnd": "*",
-        "react-dnd-html5-backend": "*",
+        "react-day-picker": "latest",
+        "react-dnd": "latest",
+        "react-dnd-html5-backend": "latest",
         "react-dom": "^19",
-        "react-hook-form": "*",
+        "react-hook-form": "latest",
         "react-resizable-panels": "^2.1.7",
         "recharts": "2.15.0",
         "sonner": "^1.7.1",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
-        "use-sync-external-store": "*",
+        "use-sync-external-store": "latest",
         "vaul": "^1.1.2",
-        "zod": "*",
-        "zustand": "*"
+        "zod": "latest",
+        "zustand": "latest"
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -71,6 +71,9 @@
         "postcss": "^8",
         "tailwindcss": "^3.4.17",
         "typescript": "^5"
+      },
+      "engines": {
+        "npm": ">=11.4.2"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -37,18 +37,22 @@
     "@radix-ui/react-toggle": "^1.1.1",
     "@radix-ui/react-toggle-group": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.6",
+    "@types/hoist-non-react-statics": "latest",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
     "date-fns": "latest",
     "embla-carousel-react": "8.5.1",
+    "immer": "latest",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",
-    "next": "16.1.5",
+    "next": "latest",
     "next-themes": "^0.4.4",
     "react": "^19",
     "react-day-picker": "latest",
+    "react-dnd": "latest",
+    "react-dnd-html5-backend": "latest",
     "react-dom": "^19",
     "react-hook-form": "latest",
     "react-resizable-panels": "^2.1.7",
@@ -56,13 +60,9 @@
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
+    "use-sync-external-store": "latest",
     "vaul": "^1.1.2",
     "zod": "latest",
-    "@types/hoist-non-react-statics": "latest",
-    "immer": "latest",
-    "use-sync-external-store": "latest",
-    "react-dnd": "latest",
-    "react-dnd-html5-backend": "latest",
     "zustand": "latest"
   },
   "devDependencies": {
@@ -72,5 +72,9 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"
+  },
+  "packageManager": "npm@11.4.2",
+  "engines": {
+    "npm": ">=11.4.2"
   }
 }


### PR DESCRIPTION
### Motivation
- Address vulnerability risk from an out-of-date Next.js release and ensure installs use a modern npm runtime.
- Make new installs pull the most recent Next.js release instead of a pinned legacy version.

### Description
- Set the `next` dependency in `package.json` to `latest` and promoted several other loose/pinned entries to `latest` to align dependency policy.
- Added `packageManager: "npm@11.4.2"` and `engines.npm: ">=11.4.2"` to `package.json` to enforce a modern npm baseline.
- Regenerated `package-lock.json` with `npm install --package-lock-only` so the lockfile metadata reflects the manifest changes and recorded the `engines.npm` constraint.
- Did not perform a full fetch of newer Next.js tarballs in this environment due to registry access restrictions, so only manifest and lock metadata were updated.

### Testing
- Ran `npm install --package-lock-only` which completed successfully.
- Ran `npm ls next --depth=0` which reported `next@16.1.5`, indicating the package was not replaced in node_modules in this environment due to registry access limits.
- Ran `npm --version` which returned `11.4.2` as recorded in the project manifest.
- Ran `npm run lint` which failed with `Invalid project directory provided, no such directory: /workspace/task-management-app/lint` (environment-specific issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699234f66c28832daeb708d994966133)